### PR TITLE
Fix batch size in inference

### DIFF
--- a/examples/cfd/vortex_shedding_mgn/inference.py
+++ b/examples/cfd/vortex_shedding_mgn/inference.py
@@ -45,7 +45,7 @@ class MGNRollout:
         # instantiate dataloader
         self.dataloader = GraphDataLoader(
             self.dataset,
-            batch_size=wb.config.batch_size,
+            batch_size=1,
             shuffle=False,
             drop_last=False,
         )


### PR DESCRIPTION
The dataloader in inference was using the configuration batch size. When loading a new graph line 82, the whole batch was loaded on a single graph. For the default config (batch_size=3), the loaded graph was: Graph(num_nodes=5769, num_edges=33210,...)  with a problem of num_nodes=1923. This lead to an error line 119, where mask and pred_i[:, 0:2] have incompatible shapes. 

This fix set the batch_size to one, to ensure the inference is running with only one graph loaded at a time to have compatible shapes.