### PR TITLE
Fixes an issue when no scaler is given, but it is present in the checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue when loading a checkpoint which contains `scaler_state_dict`, but no `scaler` provided to update. 
+
 ### Security
 
 ### Dependencies

--- a/modulus/launch/utils/checkpoint.py
+++ b/modulus/launch/utils/checkpoint.py
@@ -357,7 +357,7 @@ def load_checkpoint(
         checkpoint_logging.success("Loaded scheduler state dictionary")
 
     # Scaler state dict
-    if "scaler_state_dict" in checkpoint_dict:
+    if scaler and "scaler_state_dict" in checkpoint_dict:
         scaler.load_state_dict(checkpoint_dict["scaler_state_dict"])
         checkpoint_logging.success("Loaded grad scaler state dictionary")
 


### PR DESCRIPTION
# Modulus Pull Request

## Description
Fixes an issue when no scaler is given, but it is present in the checkpoint.
Mentioned in issue #83 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is
up to date with these changes.

## Dependencies

N/A